### PR TITLE
Load Jaeger configuration file

### DIFF
--- a/pkg/exporter/elasticsearch/config_test.go
+++ b/pkg/exporter/elasticsearch/config_test.go
@@ -31,16 +31,17 @@ func TestLoadConfigAndFlags(t *testing.T) {
 	err = c.ParseFlags([]string{"--es.server-urls=bar", "--es.index-prefix=staging", "--config-file=./testdata/jaeger-config.yaml"})
 	require.NoError(t, err)
 
+	err = flags.TryLoadConfigFile(v)
+	require.NoError(t, err)
+
 	factory := &Factory{Options: func() *es.Options {
 		opts := CreateOptions()
 		opts.InitFromViper(v)
 		require.Equal(t, []string{"bar"}, opts.GetPrimary().Servers)
 		require.Equal(t, "staging", opts.GetPrimary().GetIndexPrefix())
+		assert.Equal(t, int64(100), opts.GetPrimary().NumShards)
 		return opts
 	}}
-
-	err = flags.TryLoadConfigFile(v)
-	require.NoError(t, err)
 
 	factories.Exporters[typeStr] = factory
 	cfg, err := config.LoadConfigFile(t, path.Join(".", "testdata", "config.yaml"), factories)

--- a/pkg/exporter/elasticsearch/testdata/jaeger-config.yaml
+++ b/pkg/exporter/elasticsearch/testdata/jaeger-config.yaml
@@ -1,0 +1,2 @@
+es:
+  num-shards: 100


### PR DESCRIPTION
Related to https://github.com/jaegertracing/jaeger-opentelemetry-collector/issues/7#issuecomment-592601132

Values from Jaeger conf file will be used as default values when creating configurations objects e.g. Elasticsearch reporter. At the moment we already do this for storage flags.

Signed-off-by: Pavol Loffay <ploffay@redhat.com>