### PR TITLE
Run the service without config

### DIFF
--- a/cmd/collector/app/default_config.go
+++ b/cmd/collector/app/default_config.go
@@ -1,0 +1,73 @@
+package app
+
+import (
+	"github.com/open-telemetry/opentelemetry-collector/config"
+	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
+	"github.com/open-telemetry/opentelemetry-collector/processor/batchprocessor"
+	"github.com/open-telemetry/opentelemetry-collector/receiver"
+	"github.com/open-telemetry/opentelemetry-collector/receiver/jaegerreceiver"
+)
+
+// DefaultConfig creates default configuration.
+// It enabled default Jaeger receivers, processors and exporters.
+func DefaultConfig(factories config.Factories) *configmodels.Config {
+	return &configmodels.Config{
+		Receivers:  createReceivers(factories),
+		Exporters:  createExporters(factories),
+		Processors: createProcessors(factories),
+		Service: configmodels.Service{
+			Pipelines: map[string]*configmodels.Pipeline{
+				"traces": {
+					InputType:  configmodels.TracesDataType,
+					Receivers:  []string{"jaeger"},
+					Exporters:  []string{"jaeger_elasticsearch"},
+					Processors: []string{"batch"},
+				},
+			},
+		},
+	}
+}
+
+func createReceivers(factories config.Factories) configmodels.Receivers {
+	rec := factories.Receivers["jaeger"].CreateDefaultConfig().(*jaegerreceiver.Config)
+	// TODO load and serve sampling strategies
+	rec.Protocols = map[string]*receiver.SecureReceiverSettings{
+		"grpc": {
+			ReceiverSettings: configmodels.ReceiverSettings{
+				Endpoint: "localhost:14250",
+			},
+		},
+		"thrift_http": {
+			ReceiverSettings: configmodels.ReceiverSettings{
+				Endpoint: "localhost:14268",
+			},
+		},
+		"thrift_compact": {
+			ReceiverSettings: configmodels.ReceiverSettings{
+				Endpoint: "localhost:6831",
+			},
+		},
+		"thrift_binary": {
+			ReceiverSettings: configmodels.ReceiverSettings{
+				Endpoint: "localhost:6832",
+			},
+		},
+	}
+	return map[string]configmodels.Receiver{
+		"jaeger": rec,
+	}
+}
+
+func createExporters(factories config.Factories) configmodels.Exporters {
+	es := factories.Exporters["jaeger_elasticsearch"].CreateDefaultConfig()
+	return map[string]configmodels.Exporter{
+		"jaeger_elasticsearch": es,
+	}
+}
+
+func createProcessors(factories config.Factories) configmodels.Processors {
+	batch := factories.Processors["batch"].CreateDefaultConfig().(*batchprocessor.Config)
+	return map[string]configmodels.Processor{
+		"batch": batch,
+	}
+}

--- a/cmd/collector/app/default_config_test.go
+++ b/cmd/collector/app/default_config_test.go
@@ -1,0 +1,35 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/open-telemetry/opentelemetry-collector/config"
+	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/jaegertracing/jaeger-opentelemetry-collector/pkg/defaults"
+)
+
+func TestDefaultConfig(t *testing.T) {
+	factories, err := defaults.Components(viper.New())
+	require.NoError(t, err)
+	cfg := DefaultConfig(factories)
+	require.NoError(t, config.ValidateConfig(cfg, zap.NewNop()))
+	assert.Equal(t, 1, len(cfg.Receivers))
+	assert.Equal(t, "jaeger", cfg.Receivers["jaeger"].Name())
+	assert.Equal(t, 1, len(cfg.Processors))
+	assert.Equal(t, "batch", cfg.Processors["batch"].Name())
+	assert.Equal(t, 1, len(cfg.Exporters))
+	assert.Equal(t, "jaeger_elasticsearch", cfg.Exporters["jaeger_elasticsearch"].Name())
+	assert.EqualValues(t, map[string]*configmodels.Pipeline{
+		"traces": {
+			InputType:  configmodels.TracesDataType,
+			Receivers:  []string{"jaeger"},
+			Exporters:  []string{"jaeger_elasticsearch"},
+			Processors: []string{"batch"},
+		},
+	}, cfg.Service.Pipelines)
+}

--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -49,14 +49,8 @@ func main() {
 	factories.Exporters[esExp.Type()] = esExp
 
 	var cfgFactory service.ConfigFactory
-	f := &flag.FlagSet{}
-	builder.Flags(f)
-	// parse flags to get file
-	f.Parse(os.Args)
-	file := builder.GetConfigFile()
-	if file == "" {
+	if getConfigFile() == "" {
 		log.Println("Config file not provided, installing default Jaeger components")
-		// TODO take into account flags when creating config objects
 		cfgFactory = func(*viper.Viper, config.Factories) (*configmodels.Config, error) {
 			return createConfig(factories), nil
 		}
@@ -82,6 +76,14 @@ func main() {
 
 	err = svc.Start()
 	handleErr(err)
+}
+
+func getConfigFile() string {
+	f := &flag.FlagSet{}
+	builder.Flags(f)
+	// parse flags to get file
+	f.Parse(os.Args)
+	return builder.GetConfigFile()
 }
 
 func createConfig(factories config.Factories) *configmodels.Config {

--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -1,12 +1,19 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"log"
 	"os"
 
-	"github.com/jaegertracing/jaeger/cmd/flags"
-	"github.com/jaegertracing/jaeger/pkg/config"
+	"github.com/open-telemetry/opentelemetry-collector/config"
+	"github.com/open-telemetry/opentelemetry-collector/config/configmodels"
+	"github.com/open-telemetry/opentelemetry-collector/receiver"
+	"github.com/open-telemetry/opentelemetry-collector/receiver/jaegerreceiver"
+	"github.com/open-telemetry/opentelemetry-collector/service/builder"
+
+	jflags "github.com/jaegertracing/jaeger/cmd/flags"
+	jconfig "github.com/jaegertracing/jaeger/pkg/config"
 	"github.com/jaegertracing/jaeger/plugin/storage/es"
 	"github.com/open-telemetry/opentelemetry-collector/defaults"
 	"github.com/open-telemetry/opentelemetry-collector/service"
@@ -37,24 +44,77 @@ func main() {
 		opts.InitFromViper(v)
 		return opts
 	}}
-	cmpts, err := defaults.Components()
+	factories, err := defaults.Components()
 	handleErr(err)
-	cmpts.Exporters[esExp.Type()] = esExp
+	factories.Exporters[esExp.Type()] = esExp
 
-	svc, err := service.New(cmpts, info)
+	var cfgFactory service.ConfigFactory
+	f := &flag.FlagSet{}
+	builder.Flags(f)
+	// parse flags to get file
+	f.Parse(os.Args)
+	file := builder.GetConfigFile()
+	if file == "" {
+		log.Println("Config file not provided, installing default Jaeger components")
+		// TODO take into account flags when creating config objects
+		cfgFactory = func(*viper.Viper, config.Factories) (*configmodels.Config, error) {
+			return createConfig(factories), nil
+		}
+	}
+
+	svc, err := service.New(service.Parameters{
+		Factories:            factories,
+		ApplicationStartInfo: info,
+		ConfigFactory:        cfgFactory,
+	})
 	handleErr(err)
 
 	cmd := svc.Command()
 	opts := elasticsearch.CreateOptions()
-	config.AddFlags(v, cmd, opts.AddFlags, flags.AddConfigFileFlag)
+	jconfig.AddFlags(v, cmd, opts.AddFlags, jflags.AddConfigFileFlag)
 
 	// parse flags to propagate config file flag value to viper before service start
 	cmd.ParseFlags(os.Args)
-	err = flags.TryLoadConfigFile(v)
+	err = jflags.TryLoadConfigFile(v)
 	if err != nil {
 		handleErr(fmt.Errorf("could not load Jaeger configuration file %w", err))
 	}
 
 	err = svc.Start()
 	handleErr(err)
+}
+
+func createConfig(factories config.Factories) *configmodels.Config {
+	cfg := &configmodels.Config{}
+	jRec := factories.Receivers["jaeger"].CreateDefaultConfig().(*jaegerreceiver.Config)
+	// TODO enable other protocols
+	jRec.Protocols["grpc"] = &receiver.SecureReceiverSettings{
+		ReceiverSettings: configmodels.ReceiverSettings{
+			Endpoint: "localhost:14250",
+		},
+	}
+	cfg.Receivers = map[string]configmodels.Receiver{
+		"jaeger": jRec,
+	}
+
+	esCfg := factories.Exporters["jaeger_elasticsearch"].CreateDefaultConfig()
+	cfg.Exporters = map[string]configmodels.Exporter{
+		"jaeger_elasticsearch": esCfg,
+	}
+
+	cfg.Processors = map[string]configmodels.Processor{
+		"batch": factories.Processors["batch"].CreateDefaultConfig(),
+	}
+
+	cfg.Service = configmodels.Service{
+		Pipelines: map[string]*configmodels.Pipeline{
+			"traces": {
+				InputType:  configmodels.TracesDataType,
+				Receivers:  []string{"jaeger"},
+				Exporters:  []string{"jaeger_elasticsearch"},
+				Processors: []string{"batch"},
+			},
+		},
+	}
+	return cfg
 }

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,9 @@ go 1.13
 require (
 	github.com/fortytw2/leaktest v1.3.0 // indirect
 	github.com/jaegertracing/jaeger v1.17.0
+	github.com/magiconair/properties v1.8.1
 	github.com/olivere/elastic v6.2.27+incompatible
-	github.com/open-telemetry/opentelemetry-collector v0.2.7-0.20200227204732-6340d3c0477f
+	github.com/open-telemetry/opentelemetry-collector v0.2.8-0.20200318042533-55be0ec9ddc8
 	github.com/securego/gosec v0.0.0-20200203094520-d13bb6d2420c // indirect
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/viper v1.4.1-0.20190911140308-99520c81d86e
@@ -16,5 +17,3 @@ require (
 )
 
 replace k8s.io/client-go => k8s.io/client-go v0.0.0-20190620085101-78d2af792bab
-
-replace github.com/open-telemetry/opentelemetry-collector => /home/ploffay/projects/opentelemetry/opentelemetry-collector

--- a/go.mod
+++ b/go.mod
@@ -16,3 +16,5 @@ require (
 )
 
 replace k8s.io/client-go => k8s.io/client-go v0.0.0-20190620085101-78d2af792bab
+
+replace github.com/open-telemetry/opentelemetry-collector => /home/ploffay/projects/opentelemetry/opentelemetry-collector

--- a/go.sum
+++ b/go.sum
@@ -485,6 +485,8 @@ github.com/open-telemetry/opentelemetry-proto v0.0.0-20200206071824-8310c432e51c
 github.com/open-telemetry/opentelemetry-proto v0.0.0-20200206071824-8310c432e51c/go.mod h1:PMR5GI0F7BSpio+rBGFxNm6SLzg3FypDTcFuQZnO+F8=
 github.com/open-telemetry/opentelemetry-proto v0.0.0-20200211051721-ff5f19c6217d h1:hZcHR0at6tb3jBjaPHlfLr6yK7rTrA8xGCS6jlUSLcU=
 github.com/open-telemetry/opentelemetry-proto v0.0.0-20200211051721-ff5f19c6217d/go.mod h1:PMR5GI0F7BSpio+rBGFxNm6SLzg3FypDTcFuQZnO+F8=
+github.com/open-telemetry/opentelemetry-proto v0.0.0-20200308012146-674ae1c8703f h1:o21WlujGsrjoN3+n99AflASF/K0S6+SOLOj2O9nNplc=
+github.com/open-telemetry/opentelemetry-proto v0.0.0-20200308012146-674ae1c8703f/go.mod h1:PMR5GI0F7BSpio+rBGFxNm6SLzg3FypDTcFuQZnO+F8=
 github.com/opentracing-contrib/go-stdlib v0.0.0-20190519235532-cf7a6c988dc9/go.mod h1:PLldrQSroqzH70Xl+1DQcGnefIbqsKR7UDaiux3zV+w=
 github.com/opentracing/opentracing-go v1.1.0 h1:pWlfV3Bxv7k65HYwkikxat0+s3pV4bsqf19k25Ur8rU=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=

--- a/go.sum
+++ b/go.sum
@@ -481,12 +481,16 @@ github.com/open-telemetry/opentelemetry-collector v0.2.6 h1:2OVuxsIj/W3NYxplKTwx
 github.com/open-telemetry/opentelemetry-collector v0.2.6/go.mod h1:V1KYdNcKU2881dKDsVrFDq33isfaOcG+k7U2zynMgrk=
 github.com/open-telemetry/opentelemetry-collector v0.2.7-0.20200227204732-6340d3c0477f h1:f8wS2udDr/cE5GEV6hs7NLv8HUxll7bqWVfPlbrp8VQ=
 github.com/open-telemetry/opentelemetry-collector v0.2.7-0.20200227204732-6340d3c0477f/go.mod h1:lfnikR3CZ3ehvEo2wPPy6zSIHEKl4FrIS7nhj59QXF0=
+github.com/open-telemetry/opentelemetry-collector v0.2.8-0.20200318042533-55be0ec9ddc8 h1:weQfgq4fkJLyP00WkXE8aKqU3iU20p3EyboHnSjAo44=
+github.com/open-telemetry/opentelemetry-collector v0.2.8-0.20200318042533-55be0ec9ddc8/go.mod h1:+z/j3zjZZ3M3vlSvS4hjIIDrkBzfq8ilWlAdGPV6wlo=
 github.com/open-telemetry/opentelemetry-proto v0.0.0-20200206071824-8310c432e51c h1:nDOtl6j2Ei16tlnx/o4qKEelpHtGoZ9ArwU+tux4Ia8=
 github.com/open-telemetry/opentelemetry-proto v0.0.0-20200206071824-8310c432e51c/go.mod h1:PMR5GI0F7BSpio+rBGFxNm6SLzg3FypDTcFuQZnO+F8=
 github.com/open-telemetry/opentelemetry-proto v0.0.0-20200211051721-ff5f19c6217d h1:hZcHR0at6tb3jBjaPHlfLr6yK7rTrA8xGCS6jlUSLcU=
 github.com/open-telemetry/opentelemetry-proto v0.0.0-20200211051721-ff5f19c6217d/go.mod h1:PMR5GI0F7BSpio+rBGFxNm6SLzg3FypDTcFuQZnO+F8=
 github.com/open-telemetry/opentelemetry-proto v0.0.0-20200308012146-674ae1c8703f h1:o21WlujGsrjoN3+n99AflASF/K0S6+SOLOj2O9nNplc=
 github.com/open-telemetry/opentelemetry-proto v0.0.0-20200308012146-674ae1c8703f/go.mod h1:PMR5GI0F7BSpio+rBGFxNm6SLzg3FypDTcFuQZnO+F8=
+github.com/open-telemetry/opentelemetry-proto v0.0.0-20200315170400-caed74b167ad h1:b0fNt65HvoUg+uDe63CA08SGzKO/gzPvzQQfEFX8Oks=
+github.com/open-telemetry/opentelemetry-proto v0.0.0-20200315170400-caed74b167ad/go.mod h1:PMR5GI0F7BSpio+rBGFxNm6SLzg3FypDTcFuQZnO+F8=
 github.com/opentracing-contrib/go-stdlib v0.0.0-20190519235532-cf7a6c988dc9/go.mod h1:PLldrQSroqzH70Xl+1DQcGnefIbqsKR7UDaiux3zV+w=
 github.com/opentracing/opentracing-go v1.1.0 h1:pWlfV3Bxv7k65HYwkikxat0+s3pV4bsqf19k25Ur8rU=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -1,0 +1,25 @@
+package defaults
+
+import (
+	"github.com/jaegertracing/jaeger/plugin/storage/es"
+	"github.com/open-telemetry/opentelemetry-collector/config"
+	"github.com/open-telemetry/opentelemetry-collector/defaults"
+	"github.com/spf13/viper"
+
+	"github.com/jaegertracing/jaeger-opentelemetry-collector/pkg/exporter/elasticsearch"
+)
+
+func Components(v *viper.Viper) (config.Factories, error) {
+	esExp := elasticsearch.Factory{Options: func() *es.Options {
+		opts := elasticsearch.CreateOptions()
+		opts.InitFromViper(v)
+		return opts
+	}}
+
+	factories, err := defaults.Components()
+	if err != nil {
+		return factories, err
+	}
+	factories.Exporters[esExp.Type()] = esExp
+	return factories, nil
+}

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -9,6 +9,7 @@ import (
 	"github.com/jaegertracing/jaeger-opentelemetry-collector/pkg/exporter/elasticsearch"
 )
 
+// Components creates default and Jaeger factories
 func Components(v *viper.Viper) (config.Factories, error) {
 	esExp := elasticsearch.Factory{Options: func() *es.Options {
 		opts := elasticsearch.CreateOptions()

--- a/pkg/defaults/defaults_test.go
+++ b/pkg/defaults/defaults_test.go
@@ -1,0 +1,15 @@
+package defaults
+
+import (
+	"testing"
+
+	"github.com/magiconair/properties/assert"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+)
+
+func TestComponents(t *testing.T) {
+	factories, err := Components(viper.New())
+	require.NoError(t, err)
+	assert.Equal(t, "jaeger_elasticsearch", factories.Exporters["jaeger_elasticsearch"].Type())
+}

--- a/pkg/exporter/elasticsearch/exporter.go
+++ b/pkg/exporter/elasticsearch/exporter.go
@@ -2,6 +2,7 @@ package elasticsearch
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 
 	eswrapper "github.com/jaegertracing/jaeger/pkg/es/wrapper"
@@ -24,7 +25,7 @@ func New(config *Config, log *zap.Logger) (exporter.TraceExporter, error) {
 		elastic.SetURL(config.Servers...),
 		elastic.SetSniff(false))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create Elasticsearch client for %s, %v", config.Servers, err)
 	}
 	bulk, err := esRawClient.BulkProcessor().
 		BulkActions(config.bulkActions).

--- a/pkg/exporter/elasticsearch/factory.go
+++ b/pkg/exporter/elasticsearch/factory.go
@@ -46,6 +46,10 @@ func (f Factory) CreateDefaultConfig() configmodels.Exporter {
 		bulkWorkers:       opts.GetPrimary().BulkWorkers,
 		bulkFlushInterval: opts.GetPrimary().BulkFlushInterval,
 		Version:           opts.GetPrimary().Version,
+		ExporterSettings: configmodels.ExporterSettings{
+			TypeVal: typeStr,
+			NameVal: typeStr,
+		},
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <ploffay@redhat.com>

This PR enables running the service without providing a configuration file. When the configuration file is missing the service will use jaeger receiver, batch processor and elasticsearch exporter. The batch processor is used bc there has to be at least one processor. The storage exporter will be configurable once we have more implementations available.

Depends on https://github.com/open-telemetry/opentelemetry-collector/pull/621